### PR TITLE
Inline charts.css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "webhallen-userscript",
       "version": "1.0.1",
       "license": "GPL-3.0",
+      "dependencies": {
+        "charts.css": "^1.1.0"
+      },
       "devDependencies": {
         "@sleavely/eslint-config": "^1.0.1",
         "@types/node": "^20.10.7",
@@ -1500,6 +1503,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/charts.css": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/charts.css/-/charts.css-1.1.0.tgz",
+      "integrity": "sha512-K1Qyb8ZKsu5cDrVbZeHECk/xSq6iOl8IDTR35uaMdhr/Vyyxvg9nYQy3KNB3aidxJ2E251afX5q2725N0uL3Vw=="
     },
     "node_modules/check-error": {
       "version": "1.0.3",
@@ -5724,6 +5732,11 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "charts.css": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/charts.css/-/charts.css-1.1.0.tgz",
+      "integrity": "sha512-K1Qyb8ZKsu5cDrVbZeHECk/xSq6iOl8IDTR35uaMdhr/Vyyxvg9nYQy3KNB3aidxJ2E251afX5q2725N0uL3Vw=="
     },
     "check-error": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/webhallen.user.js",
   "scripts": {
     "build": "npm run build:compile && npm run build:header && npm run build:merge && npm run build:cleanup",
-    "build:compile": "npx esbuild --bundle src/userscript.ts --outdir=dist",
+    "build:compile": "npx esbuild --bundle src/userscript.ts --outdir=dist --loader:.css=text",
     "build:header": "npx envsub --env USER_SCRIPT_VERSION=\"$(jq .version package.json)\" --env USER_SCRIPT_DESC=\"$(jq .description package.json)\" --env USER_SCRIPT_AUTHORS=\"$(jq --join-output '.authors | join(\", \")' package.json)\" -p -s dollar-basic userscript-header.js dist/header.js",
     "build:merge": "cat dist/header.js dist/userscript.js > dist/webhallen.user.js",
     "build:cleanup": "rm dist/header.js dist/userscript.js",
@@ -35,5 +35,8 @@
     "esbuild": "^0.19.11",
     "typescript": "^5.3.3",
     "vitest": "^1.1.3"
+  },
+  "dependencies": {
+    "charts.css": "^1.1.0"
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -30,8 +30,13 @@ export const fetchAPI = async <ExpectedType = unknown> (
 }
 
 export async function fetchMe (): Promise<MeResponse['user']> {
-  const data = await fetchAPI<MeResponse>('https://www.webhallen.com/api/me')
-  return data.user
+  return await getCachedPromise({
+    key: 'me',
+    fn: async () => {
+      const data = await fetchAPI<MeResponse>('https://www.webhallen.com/api/me')
+      return data.user
+    },
+  })
 }
 
 const fetchOrdersFresh = async (whId: number): Promise<Order[]> => {

--- a/src/lib/css.ts
+++ b/src/lib/css.ts
@@ -1,0 +1,9 @@
+const addedCache = {} as Record<string, boolean>
+
+export const addCss = (css: string): void => {
+  if (addedCache[css]) return
+  const stylesheet = document.createElement('style')
+  stylesheet.innerHTML = css
+  document.head.appendChild(stylesheet)
+  addedCache[css] = true
+}

--- a/src/renderers/stats.ts
+++ b/src/renderers/stats.ts
@@ -1,4 +1,5 @@
 import { fetchAchievements, fetchOrders, fetchSupplyDrops } from '../lib/api'
+import { addCss } from '../lib/css'
 import { getCachedUser } from '../lib/userIdCache'
 import { findCategoriesByPeriod } from '../reducers/categories'
 import { type ExperienceStats, getExperienceStats } from '../reducers/experience'
@@ -6,6 +7,7 @@ import { type HoarderEntry, findTopHoarderCheevoStats } from '../reducers/hoarde
 import { findOrdersPerMonth } from '../reducers/orders'
 import { getStoreStats, type StoreSum } from '../reducers/stores'
 import { type Streaks, findStreaks } from '../reducers/streaks'
+import chartsCss from 'charts.css'
 
 function addDataToDiv (headerText: string, domObject: Element): HTMLDivElement {
   const div = document.createElement('div')
@@ -479,9 +481,14 @@ function generateStoresChart (storeSums: Map<string, StoreSum>): HTMLDivElement 
   return div
 }
 
+let addedChartsCss = false
 async function _clearAndAddStatistics (event: MouseEvent): Promise<void> {
   event.preventDefault()
-  GM_addStyle('@import url("https://unpkg.com/charts.css/dist/charts.min.css");')
+
+  if (!addedChartsCss) {
+    addCss(chartsCss)
+    addedChartsCss = true
+  }
 
   const clickedLink = event.target as HTMLElement
 

--- a/src/renderers/stats.ts
+++ b/src/renderers/stats.ts
@@ -481,14 +481,10 @@ function generateStoresChart (storeSums: Map<string, StoreSum>): HTMLDivElement 
   return div
 }
 
-let addedChartsCss = false
 async function _clearAndAddStatistics (event: MouseEvent): Promise<void> {
   event.preventDefault()
 
-  if (!addedChartsCss) {
-    addCss(chartsCss)
-    addedChartsCss = true
-  }
+  addCss(chartsCss)
 
   const clickedLink = event.target as HTMLElement
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const content
+  export default content
+}


### PR DESCRIPTION
This PR includes two changes:

* Rather than loading charts.css from unpkg.com we install it as a dependency from npm and import it as if it was an exported string from that module. We then place the string in a `<style>` tag appended to `<head>`
* The `fetchMe` method will now reuse the same network request no matter how many times it is called.